### PR TITLE
[PAY-4307] Fixed String.isNumeric() crash

### DIFF
--- a/Caishen.xcodeproj/project.pbxproj
+++ b/Caishen.xcodeproj/project.pbxproj
@@ -55,6 +55,7 @@
 		2FDD158D1CC7B3200086CEAC /* CardNumberValidatorTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDD158C1CC7B3200086CEAC /* CardNumberValidatorTests.swift */; };
 		2FDD158F1CC7B32D0086CEAC /* CardNumberFormatterTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 2FDD158E1CC7B32D0086CEAC /* CardNumberFormatterTests.swift */; };
 		7852405D2714FDB90012093D /* MultipleGroupingsCardType.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7852405C2714FDB90012093D /* MultipleGroupingsCardType.swift */; };
+		EC1B6EB32CAC52570039519D /* StringExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EC1B6EB22CAC52570039519D /* StringExtensionTests.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -121,6 +122,7 @@
 		2FDD158C1CC7B3200086CEAC /* CardNumberValidatorTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardNumberValidatorTests.swift; sourceTree = "<group>"; };
 		2FDD158E1CC7B32D0086CEAC /* CardNumberFormatterTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = CardNumberFormatterTests.swift; sourceTree = "<group>"; };
 		7852405C2714FDB90012093D /* MultipleGroupingsCardType.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MultipleGroupingsCardType.swift; sourceTree = "<group>"; };
+		EC1B6EB22CAC52570039519D /* StringExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StringExtensionTests.swift; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -180,6 +182,7 @@
 				2FDD158C1CC7B3200086CEAC /* CardNumberValidatorTests.swift */,
 				2FDD158E1CC7B32D0086CEAC /* CardNumberFormatterTests.swift */,
 				2FDD151F1CC7B0B90086CEAC /* CaishenTests.swift */,
+				EC1B6EB22CAC52570039519D /* StringExtensionTests.swift */,
 				2FDD15211CC7B0B90086CEAC /* Info.plist */,
 				7852405C2714FDB90012093D /* MultipleGroupingsCardType.swift */,
 			);
@@ -382,6 +385,7 @@
 			developmentRegion = English;
 			hasScannedForEncodings = 0;
 			knownRegions = (
+				English,
 				en,
 			);
 			mainGroup = 2FDD15061CC7B0B90086CEAC;
@@ -467,6 +471,7 @@
 				2FDD158B1CC7B30C0086CEAC /* CardExpiryValidatorTests.swift in Sources */,
 				7852405D2714FDB90012093D /* MultipleGroupingsCardType.swift in Sources */,
 				2FDD15891CC7B2FD0086CEAC /* CardCVCValidatorTests.swift in Sources */,
+				EC1B6EB32CAC52570039519D /* StringExtensionTests.swift in Sources */,
 				2FDD158F1CC7B32D0086CEAC /* CardNumberFormatterTests.swift in Sources */,
 				2FDD158D1CC7B3200086CEAC /* CardNumberValidatorTests.swift in Sources */,
 				2FDD15201CC7B0B90086CEAC /* CaishenTests.swift in Sources */,
@@ -532,7 +537,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = YES;
 				ONLY_ACTIVE_ARCH = YES;
 				SDKROOT = iphoneos;
@@ -585,7 +590,7 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES_AGGRESSIVE;
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
-				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
+				IPHONEOS_DEPLOYMENT_TARGET = 15.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
 				TARGETED_DEVICE_FAMILY = "1,2";

--- a/CaishenTests/StringExtensionTests.swift
+++ b/CaishenTests/StringExtensionTests.swift
@@ -1,0 +1,13 @@
+import XCTest
+@testable import Caishen
+
+final class StringExtensionTests: XCTestCase {
+  func testIsNumeric() {
+    XCTAssertTrue("0".isNumeric())
+    XCTAssertTrue("1".isNumeric())
+    XCTAssertFalse("1.5".isNumeric())
+    XCTAssertFalse("a".isNumeric())
+    XCTAssertFalse("1️⃣".isNumeric())
+    XCTAssertFalse("🔥".isNumeric())
+  }
+}

--- a/Pod/Classes/StringExtension.swift
+++ b/Pod/Classes/StringExtension.swift
@@ -33,12 +33,6 @@ extension String {
      - returns: True if this string contains only digits.
      */
     func isNumeric() -> Bool {
-        return reduce(true, { (result, value) in
-            let string = String(value)
-            guard let firstChar = string.utf16.first else {
-                return result
-            }
-            return result && CharacterSet.decimalDigits.contains(UnicodeScalar(firstChar)!)}
-        )
+      return CharacterSet(charactersIn: self).isSubset(of: CharacterSet.decimalDigits)
     }
 }


### PR DESCRIPTION
Fix crash in [Fatal error StringExtension.swift:41 ](https://app.bugsnag.com/glovoapp23-sa/glovo-customer-ios-prod/errors/5e91f758093d0b0017461061?filters%5Bapp.release_stage%5D=Production&filters%5Bevent.unhandled%5D=true&filters%5Bevent.since%5D=7d&filters%5Bevent.class%5D%5Btype%5D=ne&filters%5Bevent.class%5D%5Bvalue%5D=App%20Hang)

`String.isNumeric()` is crashing when using with special characters

[PAY-4307](https://glovoapp.atlassian.net/browse/PAY-4307)

[PAY-4307]: https://glovoapp.atlassian.net/browse/PAY-4307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ